### PR TITLE
partitions: Fix path based Find_Next_Storage

### DIFF
--- a/partitionmanager.cpp
+++ b/partitionmanager.cpp
@@ -1516,7 +1516,7 @@ TWPartition* TWPartitionManager::Find_Next_Storage(string Path, bool Exclude_Dat
 	if (!Path.empty()) {
 		string Search_Path = TWFunc::Get_Root_Path(Path);
 		for (; iter != Partitions.end(); iter++) {
-			if (Exclude_Data_Media && (*iter)->Has_Data_Media) {
+			if ((*iter)->Mount_Point == Search_Path) {
 				iter++;
 				break;
 			}


### PR DESCRIPTION
If a path is specified for Find_Next_Storage() and datamedia is
excluded, the function currently runs to the end of available
partitions and reports no other storage is available. Fix this by
restoring the original mount_point == search_path check to break the
loop. The subsequent partitions loop will skip data-media storage as
needed.

Change-Id: I92baed866cd36f13d851bd58ba5346e47edb142e